### PR TITLE
Prevent too fast key repeats issued by IR remote.

### DIFF
--- a/remote.cpp
+++ b/remote.cpp
@@ -16,6 +16,7 @@ Remote::Remote(int pin)
     remote->blink13(false);
     remote->enableIRIn();
     last_event = EVENT_NONE;
+    next_repeat_time = 0;
 }
 
 int Remote::clear(int timeout){
@@ -31,8 +32,7 @@ unsigned Remote::read(void){
         remote->resume();
         switch (code){
         case 0xFFFFFFFF: // repeat
-            // I have to turn this off for OK/Cancel, as most keys are repeated
-            if (!(last_event & (EVENT_OK|EVENT_CANCEL))){
+            if (millis() > next_repeat_time){
                 event = last_event;
             }
             break;
@@ -61,7 +61,10 @@ unsigned Remote::read(void){
             Serial.print("Unknown remote code ");
             Serial.println(code, HEX);
         };
-        last_event = event;
+        if (event && last_event != event){
+            last_event = event;
+            next_repeat_time = millis() + REPEAT_DELAY;
+        }
     }
     return event;
 }

--- a/remote.h
+++ b/remote.h
@@ -13,10 +13,15 @@
 #include <IRremote.h>
 #include "hid.h"
 
+// the remote I have sends repeat code too quick
+// allow repeat code only after this many milliseconds
+#define REPEAT_DELAY 500
+
 class Remote : public HID {
 private:
     int pin;
-    int last_event;
+    unsigned last_event;
+    unsigned next_repeat_time;
     IRrecv* remote;
     decode_results remote_buffer;
 protected:


### PR DESCRIPTION
My cheap IR remote sends repeat codes almost immediately after each key press, making menu navigation annoying. This introduces a 0.5s delay before repeat codes are accepted, making the previous hack to ignore repeats for OK/CANCEL no longer needed.
